### PR TITLE
Return 0 from execute function

### DIFF
--- a/src/Commands/PushStateToCyclopsCommand.php
+++ b/src/Commands/PushStateToCyclopsCommand.php
@@ -13,6 +13,7 @@ abstract class PushStateToCyclopsCommand extends CustardCommand
     final function execute(InputInterface $input, OutputInterface $output)
     {
         $this->executeUseCase();
+        return 0;
     }
 
     abstract protected function getService(): CyclopsService;


### PR DESCRIPTION
with jobfinder now on php8 it requires functions to return the correct type that is in its method signature