### PR TITLE
Change Final Methods to Protected

### DIFF
--- a/src/Commands/PushDeletedToCyclopsCommand.php
+++ b/src/Commands/PushDeletedToCyclopsCommand.php
@@ -6,7 +6,7 @@ use Gcd\Cyclops\UseCases\PushDeletedToCyclopsUseCase;
 
 abstract class PushDeletedToCyclopsCommand extends PushStateToCyclopsCommand
 {
-    final function executeUseCase()
+    protected function executeUseCase()
     {
         $pushUseCase = new PushDeletedToCyclopsUseCase($this->getService());
         $pushUseCase->execute($this->getList(), $this->onCustomerDeleted());

--- a/src/Commands/PushStaleToCyclopsCommand.php
+++ b/src/Commands/PushStaleToCyclopsCommand.php
@@ -6,7 +6,7 @@ use Gcd\Cyclops\UseCases\PushStaleToCyclopsUseCase;
 
 abstract class PushStaleToCyclopsCommand extends PushStateToCyclopsCommand
 {
-    final function executeUseCase()
+    protected function executeUseCase()
     {
         $pushUseCase = new PushStaleToCyclopsUseCase($this->getService());
         $pushUseCase->execute($this->getList(), $this->getCustomerPushedHandler());


### PR DESCRIPTION
Changed to allow method overrides to facilitate error handling in jobfinder