### PR TITLE
Throw new CyclopsException for deleted user not found

### DIFF
--- a/src/UseCases/PushDeletedToCyclopsUseCase.php
+++ b/src/UseCases/PushDeletedToCyclopsUseCase.php
@@ -24,12 +24,22 @@ class PushDeletedToCyclopsUseCase
         foreach ($list->items as $item) {
             try {
                 $this->cyclopsService->deleteCustomer($item->identity, $item->timestamp);
+
                 if ($onCustomerDeleted !== null) {
+                    // Set CyclopsQueue item to sent
                     $onCustomerDeleted($item, true);
                 }
             } catch (CustomerNotFoundException $exception) {
                 if ($onCustomerDeleted !== null) {
+                    // Set CyclopsQueue item to not sent
                     $onCustomerDeleted($item, false);
+
+                    // Throw new exception to trigger retry request and/or failure email
+                    throw new CyclopsException(
+                        "404 Customer Not Found and queue item not sent",
+                        404,
+                        $exception
+                    );
                 }
             }
         }

--- a/src/UseCases/PushStaleToCyclopsUseCase.php
+++ b/src/UseCases/PushStaleToCyclopsUseCase.php
@@ -26,12 +26,15 @@ class PushStaleToCyclopsUseCase
                     throw new CustomerNotFoundException();
                 }
                 $this->cyclopsService->setBrandOptInStatus($item);
+
+                // Set CyclopsQueue item to not sent
                 $onItemPushed($item, false);
             } catch (CustomerNotFoundException $exception) {
                 $customer = $this->cyclopsService->loadCustomer($item->identity, $item->timestamp);
                 $customer->brandOptIn = $item->brandOptIn;
                 $this->cyclopsService->setBrandOptInStatus($customer);
 
+                // Set CyclopsQueue item to sent
                 $onItemPushed($item, true, $customer);
             }
         }


### PR DESCRIPTION
Throw a CyclopsException when a CustomerNotFoundException is caught so that we can retry the request and/or send the failure email. 
Also added some clarifying comments.